### PR TITLE
feat(application-template): promethus metric 지원 추가

### DIFF
--- a/charts/application-template/Chart.yaml
+++ b/charts/application-template/Chart.yaml
@@ -9,4 +9,4 @@ maintainers:
 - name: modusign
   url: https://github.com/modusign
 name: application-template
-version: 1.3.2
+version: 1.4.0

--- a/charts/application-template/templates/scheduler/deployment.yaml
+++ b/charts/application-template/templates/scheduler/deployment.yaml
@@ -105,7 +105,7 @@ spec:
         {{- end }}
         {{- if .Values.global.observability.prometheus.enabled }}
           - name: metrics
-            port: {{ .Values.global.observability.prometheus.port }}
+            containerPort: {{ .Values.global.observability.prometheus.port }}
             protocol: TCP
         {{- end }}
         {{- with .Values.scheduler.livenessProbe }}

--- a/charts/application-template/templates/scheduler/deployment.yaml
+++ b/charts/application-template/templates/scheduler/deployment.yaml
@@ -103,6 +103,11 @@ spec:
             containerPort: {{ .targetPort }}
             protocol: TCP
         {{- end }}
+        {{- if .Values.global.observability.prometheus.enabled }}
+          - name: metrics
+            port: {{ .Values.global.observability.prometheus.port }}
+            protocol: TCP
+        {{- end }}
         {{- with .Values.scheduler.livenessProbe }}
         livenessProbe:
           httpGet:

--- a/charts/application-template/templates/scheduler/deployment.yaml
+++ b/charts/application-template/templates/scheduler/deployment.yaml
@@ -105,7 +105,7 @@ spec:
         {{- end }}
         {{- if .Values.global.observability.prometheus.enabled }}
           - name: metrics
-            containerPort: {{ .Values.global.observability.prometheus.port }}
+            containerPort: {{ default .Values.global.observability.prometheus.port .Values.global.observability.prometheus.targetPort }}
             protocol: TCP
         {{- end }}
         {{- with .Values.scheduler.livenessProbe }}

--- a/charts/application-template/templates/scheduler/service.yaml
+++ b/charts/application-template/templates/scheduler/service.yaml
@@ -13,6 +13,13 @@ spec:
       targetPort: {{ .targetPort }}
       protocol: TCP
 {{- end }}
+{{- if .Values.global.observability.prometheus.enabled }}
+{{- with .Values.global.observability.prometheus }}
+    - name: metrics
+      port: {{ .port }}
+      protocol: TCP
+{{- end }}
+{{- end }}
   selector:
     {{- include "application.scheduler.selectorLabels" . | nindent 4 }}
 {{- end }}

--- a/charts/application-template/templates/scheduler/service.yaml
+++ b/charts/application-template/templates/scheduler/service.yaml
@@ -17,6 +17,9 @@ spec:
 {{- with .Values.global.observability.prometheus }}
     - name: metrics
       port: {{ .port }}
+      {{- if .targetPort }}
+      targetPort: {{ .targetPort }}
+      {{- end }}
       protocol: TCP
 {{- end }}
 {{- end }}

--- a/charts/application-template/templates/server/deployment.yaml
+++ b/charts/application-template/templates/server/deployment.yaml
@@ -105,7 +105,7 @@ spec:
         {{- end }}
         {{- if .Values.global.observability.prometheus.enabled }}
           - name: metrics
-            containerPort: {{ .Values.global.observability.prometheus.port }}
+            containerPort: {{ default .Values.global.observability.prometheus.port .Values.global.observability.prometheus.targetPort }}
             protocol: TCP
         {{- end }}
         {{- with .Values.server.livenessProbe }}

--- a/charts/application-template/templates/server/deployment.yaml
+++ b/charts/application-template/templates/server/deployment.yaml
@@ -105,7 +105,7 @@ spec:
         {{- end }}
         {{- if .Values.global.observability.prometheus.enabled }}
           - name: metrics
-            port: {{ .Values.global.observability.prometheus.port }}
+            containerPort: {{ .Values.global.observability.prometheus.port }}
             protocol: TCP
         {{- end }}
         {{- with .Values.server.livenessProbe }}

--- a/charts/application-template/templates/server/deployment.yaml
+++ b/charts/application-template/templates/server/deployment.yaml
@@ -103,6 +103,11 @@ spec:
             containerPort: {{ .targetPort }}
             protocol: TCP
         {{- end }}
+        {{- if .Values.global.observability.prometheus.enabled }}
+          - name: metrics
+            port: {{ .Values.global.observability.prometheus.port }}
+            protocol: TCP
+        {{- end }}
         {{- with .Values.server.livenessProbe }}
         livenessProbe:
           httpGet:

--- a/charts/application-template/templates/server/service.yaml
+++ b/charts/application-template/templates/server/service.yaml
@@ -17,6 +17,9 @@ spec:
 {{- with .Values.global.observability.prometheus }}
     - name: metrics
       port: {{ .port }}
+      {{- if .targetPort }}
+      targetPort: {{ .targetPort }}
+      {{- end }}
       protocol: TCP
 {{- end }}
 {{- end }}

--- a/charts/application-template/templates/server/service.yaml
+++ b/charts/application-template/templates/server/service.yaml
@@ -13,6 +13,13 @@ spec:
       targetPort: {{ .targetPort }}
       protocol: TCP
 {{- end }}
+{{- if .Values.global.observability.prometheus.enabled }}
+{{- with .Values.global.observability.prometheus }}
+    - name: metrics
+      port: {{ .port }}
+      protocol: TCP
+{{- end }}
+{{- end }}
   selector:
     {{- include "application.server.selectorLabels" . | nindent 4 }}
 {{- end }}

--- a/charts/application-template/templates/service_monitor.yaml
+++ b/charts/application-template/templates/service_monitor.yaml
@@ -1,0 +1,18 @@
+{{- if and .Values.global.observability.prometheus.enabled .Values.global.observability.prometheus.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "application.name" . }}
+  labels:
+    {{- include "application.commonLabels" . | nindent 4 }}
+spec:
+  endpoints:
+    - path: {{ .Values.global.observability.prometheus.path }}
+      port: metrics
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+{{ include "application.commonLabels" . | indent 6}}
+{{- end }}

--- a/charts/application-template/templates/service_monitor.yaml
+++ b/charts/application-template/templates/service_monitor.yaml
@@ -14,5 +14,5 @@ spec:
       - {{ .Release.Namespace }}
   selector:
     matchLabels:
-{{ include "application.commonLabels" . | indent 6}}
+      {{- include "application.commonLabels" . | nindent 6}}
 {{- end }}

--- a/charts/application-template/templates/worker/deployment.yaml
+++ b/charts/application-template/templates/worker/deployment.yaml
@@ -105,7 +105,7 @@ spec:
         {{- end }}
         {{- if .Values.global.observability.prometheus.enabled }}
           - name: metrics
-            containerPort: {{ .Values.global.observability.prometheus.port }}
+            containerPort: {{ default .Values.global.observability.prometheus.port .Values.global.observability.prometheus.targetPort }}
             protocol: TCP
         {{- end }}
         {{- with .Values.worker.livenessProbe }}

--- a/charts/application-template/templates/worker/deployment.yaml
+++ b/charts/application-template/templates/worker/deployment.yaml
@@ -105,7 +105,7 @@ spec:
         {{- end }}
         {{- if .Values.global.observability.prometheus.enabled }}
           - name: metrics
-            port: {{ .Values.global.observability.prometheus.port }}
+            containerPort: {{ .Values.global.observability.prometheus.port }}
             protocol: TCP
         {{- end }}
         {{- with .Values.worker.livenessProbe }}

--- a/charts/application-template/templates/worker/deployment.yaml
+++ b/charts/application-template/templates/worker/deployment.yaml
@@ -103,6 +103,11 @@ spec:
             containerPort: {{ .targetPort }}
             protocol: TCP
         {{- end }}
+        {{- if .Values.global.observability.prometheus.enabled }}
+          - name: metrics
+            port: {{ .Values.global.observability.prometheus.port }}
+            protocol: TCP
+        {{- end }}
         {{- with .Values.worker.livenessProbe }}
         livenessProbe:
           httpGet:

--- a/charts/application-template/templates/worker/service.yaml
+++ b/charts/application-template/templates/worker/service.yaml
@@ -17,6 +17,9 @@ spec:
 {{- with .Values.global.observability.prometheus }}
     - name: metrics
       port: {{ .port }}
+      {{- if .targetPort }}
+      targetPort: {{ .targetPort }}
+      {{- end }}
       protocol: TCP
 {{- end }}
 {{- end }}

--- a/charts/application-template/templates/worker/service.yaml
+++ b/charts/application-template/templates/worker/service.yaml
@@ -13,6 +13,13 @@ spec:
       targetPort: {{ .targetPort }}
       protocol: TCP
 {{- end }}
+{{- if .Values.global.observability.prometheus.enabled }}
+{{- with .Values.global.observability.prometheus }}
+    - name: metrics
+      port: {{ .port }}
+      protocol: TCP
+{{- end }}
+{{- end }}
   selector:
     {{- include "application.worker.selectorLabels" . | nindent 4 }}
 {{- end }}

--- a/charts/application-template/values.yaml
+++ b/charts/application-template/values.yaml
@@ -108,7 +108,7 @@ global:
     # -- set up additional service port and setup
     prometheus:
       enabled: false
-      port: 9090
+      port: 9100
       path: /metrics
       # -- create Prometheus Operator ServiceMonitorCR
       serviceMonitor:

--- a/charts/application-template/values.yaml
+++ b/charts/application-template/values.yaml
@@ -109,6 +109,7 @@ global:
     prometheus:
       enabled: false
       port: 9100
+      # targetPort: 9100
       path: /metrics
       # -- create Prometheus Operator ServiceMonitorCR
       serviceMonitor:

--- a/charts/application-template/values.yaml
+++ b/charts/application-template/values.yaml
@@ -105,9 +105,14 @@ global:
     datadog:
       admissionController:
         enabled: false
-    # -- inject grafana
-    # grafana:
-    #   enabled: false
+    # -- set up additional service port and setup
+    prometheus:
+      enabled: true
+      port: 9090
+      path: /metrics
+      # -- create Prometheus Operator ServiceMonitorCR
+      serviceMonitor:
+        enabled: true
 
 ## Server
 server:

--- a/charts/application-template/values.yaml
+++ b/charts/application-template/values.yaml
@@ -107,12 +107,12 @@ global:
         enabled: false
     # -- set up additional service port and setup
     prometheus:
-      enabled: true
+      enabled: false
       port: 9090
       path: /metrics
       # -- create Prometheus Operator ServiceMonitorCR
       serviceMonitor:
-        enabled: true
+        enabled: false
 
 ## Server
 server:

--- a/charts/application-template/values.yaml
+++ b/charts/application-template/values.yaml
@@ -113,7 +113,7 @@ global:
       path: /metrics
       # -- create Prometheus Operator ServiceMonitorCR
       serviceMonitor:
-        enabled: false
+        enabled: true
 
 ## Server
 server:


### PR DESCRIPTION
`global.observability.prometheus`의 값에 따라 Service에 메트릭 포트를 추가하고 Prometheus operator의 ServiceMonitor CR를 생성하도록 합니다.

- feat(application-template): prometheus metric, operator를 지원하도록 service, serviceMonitor 수정
- feat: pod에서 prometheus metrics port 노출
