### PR TITLE
fix(application-template): capability api 제거, 오타 수정

### DIFF
--- a/charts/application-template/Chart.yaml
+++ b/charts/application-template/Chart.yaml
@@ -9,4 +9,4 @@ maintainers:
 - name: modusign
   url: https://github.com/modusign
 name: application-template
-version: 1.5.0
+version: 1.5.1

--- a/charts/application-template/templates/scheduler/prometheus-rule.yaml
+++ b/charts/application-template/templates/scheduler/prometheus-rule.yaml
@@ -1,4 +1,3 @@
-{{- if .Capabilities.APIVersions.Has "monitoring.coreos.com/v1/PrometheusRule" }}
 {{- if and .Values.scheduler.enabled (or .Values.scheduler.observability.prometheus.alerting_rules.enabled .Values.scheduler.observability.prometheus.istio_alerting_rules.enabled) }}
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
@@ -77,5 +76,4 @@ spec:
             summary: "[{{ include "application.scheduler.name" . | title }}][istio-proxy] High memory usage"
             description: "[{{ include "application.scheduler.name" . | title }}][istio-proxy] 서비스의 최근 메모리 사용량이 {{ .Values.scheduler.observability.prometheus.istio_alerting_rules.highMemoryUsageThreshold }}% 이상이 되었습니다. 현재값: {{`{{ .Value | humanize }}`}}%"
     {{- end }}
-{{- end }}
 {{- end }}

--- a/charts/application-template/templates/server/prometheus-rule.yaml
+++ b/charts/application-template/templates/server/prometheus-rule.yaml
@@ -1,5 +1,5 @@
 {{- if .Capabilities.APIVersions.Has "monitoring.coreos.com/v1/PrometheusRule" }}
-{{- if and .Values.server.enabled (or .Values.server.observability.prometheus.rules.enabled .Values.server.observability.prometheus.istio_rules.enabled) }}
+{{- if and .Values.server.enabled (or .Values.server.observability.prometheus.alerting_rules.enabled .Values.server.observability.prometheus.istio_alerting_rules.enabled) }}
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
@@ -7,9 +7,9 @@ metadata:
   namespace: {{ .Release.Namespace }}
 spec:
   groups:
-    {{- if .Values.server.observability.prometheus.rules.enabled }}
+    {{- if .Values.server.observability.prometheus.alerting_rules.enabled }}
     - name: ServiceContainerResourceUsage
-      rules:
+      alerting_rules:
         - alert: "HighServiceContainerCPUUsage"
           expr: |
             avg(
@@ -18,13 +18,13 @@ spec:
                 (kube_pod_container_resource_limits{ resource="cpu", container={{ .Values.server.name | quote }} })
             )
             * 100
-            > {{ .Values.server.observability.prometheus.rules.highCpuUsageThreshold }}
+            > {{ .Values.server.observability.prometheus.alerting_rules.highCpuUsageThreshold }}
           for: 5m
           labels:
             severity: critical
           annotations:
             summary: "[{{ include "application.server.name" . | title }}] High CPU usage"
-            description: "[{{ include "application.server.name" . | title }}] 서비스의 최근 CPU 사용량이 {{ .Values.server.observability.prometheus.rules.highCpuUsageThreshold }}% 이상이 되었습니다. 현재값: {{`{{ .Value | humanize }}`}}%"
+            description: "[{{ include "application.server.name" . | title }}] 서비스의 최근 CPU 사용량이 {{ .Values.server.observability.prometheus.alerting_rules.highCpuUsageThreshold }}% 이상이 되었습니다. 현재값: {{`{{ .Value | humanize }}`}}%"
 
         - alert: HighServiceContainerMemoryUsage
           expr: |
@@ -33,18 +33,18 @@ spec:
                 / on(pod)
                 (kube_pod_container_resource_limits{ resource="memory", container={{ .Values.server.name | quote }} })
             ) * 100
-            > {{ .Values.server.observability.prometheus.rules.highMemoryUsageThreshold }}
+            > {{ .Values.server.observability.prometheus.alerting_rules.highMemoryUsageThreshold }}
           for: 5m
           labels:
             service: {{ include "application.server.name" . | quote }}
             severity: critical
           annotations:
             summary: "[{{ include "application.server.name" . | title }}] High memory usage"
-            description: "[{{ include "application.server.name" . | title }}] 서비스의 최근 메모리 사용량이 {{ .Values.server.observability.prometheus.rules.highMemoryUsageThreshold }}% 이상이 되었습니다. 현재값: {{`{{ .Value | humanize }}`}}%"
+            description: "[{{ include "application.server.name" . | title }}] 서비스의 최근 메모리 사용량이 {{ .Values.server.observability.prometheus.alerting_rules.highMemoryUsageThreshold }}% 이상이 되었습니다. 현재값: {{`{{ .Value | humanize }}`}}%"
     {{- end }}
-    {{- if .Values.server.observability.prometheus.istio_rules.enabled }}
+    {{- if .Values.server.observability.prometheus.istio_alerting_rules.enabled }}
     - name: IstioContainerResourceUsage
-      rules:
+      alerting_rules:
         - alert: "HighIstioContainerCPUUsage"
           expr: |
             avg(
@@ -53,13 +53,13 @@ spec:
                 (kube_pod_container_resource_limits{ resource="cpu", container="istio-proxy" })
             )
             * 100
-            > {{ .Values.server.observability.prometheus.istio_rules.highCpuUsageThreshold }}
+            > {{ .Values.server.observability.prometheus.istio_alerting_rules.highCpuUsageThreshold }}
           for: 5m
           labels:
             severity: critical
           annotations:
             summary: "[{{ include "application.server.name" . | title }}][istio-proxy] High CPU usage"
-            description: "[{{ include "application.server.name" . | title }}][istio-proxy] 서비스의 최근 CPU 사용량이 {{ .Values.server.observability.prometheus.istio_rules.highCpuUsageThreshold }}% 이상이 되었습니다. 현재값: {{`{{ .Value | humanize }}`}}%"
+            description: "[{{ include "application.server.name" . | title }}][istio-proxy] 서비스의 최근 CPU 사용량이 {{ .Values.server.observability.prometheus.istio_alerting_rules.highCpuUsageThreshold }}% 이상이 되었습니다. 현재값: {{`{{ .Value | humanize }}`}}%"
 
         - alert: HighIstioContainerMemoryUsage
           expr: |
@@ -68,14 +68,14 @@ spec:
                 / on(pod)
                 (kube_pod_container_resource_limits{ resource="memory", container="istio-proxy" })
             ) * 100
-            > {{ .Values.server.observability.prometheus.istio_rules.highMemoryUsageThreshold }}
+            > {{ .Values.server.observability.prometheus.istio_alerting_rules.highMemoryUsageThreshold }}
           for: 5m
           labels:
             service: {{ include "application.server.name" . | quote }}
             severity: critical
           annotations:
             summary: "[{{ include "application.server.name" . | title }}][istio-proxy] High memory usage"
-            description: "[{{ include "application.server.name" . | title }}][istio-proxy] 서비스의 최근 메모리 사용량이 {{ .Values.server.observability.prometheus.istio_rules.highMemoryUsageThreshold }}% 이상이 되었습니다. 현재값: {{`{{ .Value | humanize }}`}}%"
+            description: "[{{ include "application.server.name" . | title }}][istio-proxy] 서비스의 최근 메모리 사용량이 {{ .Values.server.observability.prometheus.istio_alerting_rules.highMemoryUsageThreshold }}% 이상이 되었습니다. 현재값: {{`{{ .Value | humanize }}`}}%"
     {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/application-template/templates/server/prometheus-rule.yaml
+++ b/charts/application-template/templates/server/prometheus-rule.yaml
@@ -1,4 +1,3 @@
-{{- if .Capabilities.APIVersions.Has "monitoring.coreos.com/v1/PrometheusRule" }}
 {{- if and .Values.server.enabled (or .Values.server.observability.prometheus.alerting_rules.enabled .Values.server.observability.prometheus.istio_alerting_rules.enabled) }}
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
@@ -77,5 +76,4 @@ spec:
             summary: "[{{ include "application.server.name" . | title }}][istio-proxy] High memory usage"
             description: "[{{ include "application.server.name" . | title }}][istio-proxy] 서비스의 최근 메모리 사용량이 {{ .Values.server.observability.prometheus.istio_alerting_rules.highMemoryUsageThreshold }}% 이상이 되었습니다. 현재값: {{`{{ .Value | humanize }}`}}%"
     {{- end }}
-{{- end }}
 {{- end }}

--- a/charts/application-template/templates/service_monitor.yaml
+++ b/charts/application-template/templates/service_monitor.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.global.observability.prometheus.serviceMonitor.enabled  (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1/ServiceMonitor") }}
+{{- if .Values.global.observability.prometheus.serviceMonitor.enabled  }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:

--- a/charts/application-template/templates/worker/prometheus-rule.yaml
+++ b/charts/application-template/templates/worker/prometheus-rule.yaml
@@ -1,4 +1,3 @@
-{{- if .Capabilities.APIVersions.Has "monitoring.coreos.com/v1/PrometheusRule" }}
 {{- if and .Values.worker.enabled (or .Values.worker.observability.prometheus.alerting_rules.enabled .Values.worker.observability.prometheus.istio_alerting_rules.enabled) }}
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
@@ -77,5 +76,4 @@ spec:
             summary: "[{{ include "application.worker.name" . | title }}][istio-proxy] High memory usage"
             description: "[{{ include "application.worker.name" . | title }}][istio-proxy] 서비스의 최근 메모리 사용량이 {{ .Values.worker.observability.prometheus.istio_alerting_rules.highMemoryUsageThreshold }}% 이상이 되었습니다. 현재값: {{`{{ .Value | humanize }}`}}%"
     {{- end }}
-{{- end }}
 {{- end }}


### PR DESCRIPTION
- **fix: typo**: server/prometheus-rule.yaml에 rules를 alert_rules로 수정
- **fix: remove capability api**: argo CD에서 helm 사용할 때 helm의 capability api가 잘 작동하지 않는다고 합니다. [1]
- **fix: update chart version**

[1]: https://github.com/helm/helm/issues/10760#issuecomment-1065239645