### PR TITLE
feat(application-template): add Gateway API Gateway resource support

### DIFF
--- a/charts/application-template/Chart.yaml
+++ b/charts/application-template/Chart.yaml
@@ -9,4 +9,4 @@ maintainers:
   - name: modusign
     url: https://github.com/modusign
 name: application-template
-version: 1.10.0
+version: 1.11.0

--- a/charts/application-template/README.md
+++ b/charts/application-template/README.md
@@ -1,6 +1,6 @@
 # application-template
 
-![Version: 1.10.0](https://img.shields.io/badge/Version-1.10.0-informational?style=flat-square) ![AppVersion: v1.0.0](https://img.shields.io/badge/AppVersion-v1.0.0-informational?style=flat-square)
+![Version: 1.11.0](https://img.shields.io/badge/Version-1.11.0-informational?style=flat-square) ![AppVersion: v1.0.0](https://img.shields.io/badge/AppVersion-v1.0.0-informational?style=flat-square)
 
 A Helm chart for Modusign Applications
 
@@ -79,6 +79,7 @@ Kubernetes: `>=1.23`
 | scheduler.initContainers | list | `[]` | Init containers to add to the application scheduler pod |
 | scheduler.istio.destinationRules | list | `[]` | destinationRule configuration |
 | scheduler.istio.enabled | bool | `false` | Create istio resources |
+| scheduler.istio.gateways | list | `[]` | Kubernetes Gateway API Gateway 리소스 배열 |
 | scheduler.istio.httpRoutes | list | `[]` | Kubernetes Gateway API HTTPRoute 리소스 배열 |
 | scheduler.istio.ingressGateways | list | `[]` | ingress gateway configuration |
 | scheduler.istio.mode | string | `""` | Override global istio mode for this component (sidecar | ambient). Empty = use global. |
@@ -159,6 +160,7 @@ Kubernetes: `>=1.23`
 | server.initContainers | list | `[]` | Init containers to add to the application server pod |
 | server.istio.destinationRules | list | `[]` | destinationRule configuration |
 | server.istio.enabled | bool | `true` | Create istio resources |
+| server.istio.gateways | list | `[]` | Kubernetes Gateway API Gateway 리소스 배열 |
 | server.istio.httpRoutes | list | `[]` | Kubernetes Gateway API HTTPRoute 리소스 배열 |
 | server.istio.ingressGateways | list | `[]` | ingress gateway configuration |
 | server.istio.mode | string | `""` | Override global istio mode for this component (sidecar | ambient). Empty = use global. |
@@ -236,6 +238,7 @@ Kubernetes: `>=1.23`
 | worker.initContainers | list | `[]` | Init containers to add to the application worker pod |
 | worker.istio.destinationRules | list | `[]` | destinationRule configuration |
 | worker.istio.enabled | bool | `false` | Create istio resources |
+| worker.istio.gateways | list | `[]` | Kubernetes Gateway API Gateway 리소스 배열 |
 | worker.istio.httpRoutes | list | `[]` | Kubernetes Gateway API HTTPRoute 리소스 배열 |
 | worker.istio.ingressGateways | list | `[]` | ingress gateway configuration |
 | worker.istio.mode | string | `""` | Override global istio mode for this component (sidecar | ambient). Empty = use global. |

--- a/charts/application-template/templates/scheduler/gateway-api-gateway.yaml
+++ b/charts/application-template/templates/scheduler/gateway-api-gateway.yaml
@@ -1,0 +1,29 @@
+{{- if .Values.scheduler.enabled }}
+{{- if .Values.scheduler.istio.enabled }}
+{{- range $index, $gateway := .Values.scheduler.istio.gateways }}
+{{- with $gateway }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: {{ .name }}
+  labels:
+    {{- include "application.scheduler.labels" $ | nindent 4 }}
+spec:
+  gatewayClassName: {{ .gatewayClassName }}
+  {{- with .addresses }}
+  addresses:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .infrastructure }}
+  infrastructure:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .listeners }}
+  listeners:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}
+---
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/application-template/templates/server/gateway-api-gateway.yaml
+++ b/charts/application-template/templates/server/gateway-api-gateway.yaml
@@ -1,0 +1,29 @@
+{{- if .Values.server.enabled }}
+{{- if .Values.server.istio.enabled }}
+{{- range $index, $gateway := .Values.server.istio.gateways }}
+{{- with $gateway }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: {{ .name }}
+  labels:
+    {{- include "application.server.labels" $ | nindent 4 }}
+spec:
+  gatewayClassName: {{ .gatewayClassName }}
+  {{- with .addresses }}
+  addresses:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .infrastructure }}
+  infrastructure:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .listeners }}
+  listeners:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}
+---
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/application-template/templates/worker/gateway-api-gateway.yaml
+++ b/charts/application-template/templates/worker/gateway-api-gateway.yaml
@@ -1,0 +1,29 @@
+{{- if .Values.worker.enabled }}
+{{- if .Values.worker.istio.enabled }}
+{{- range $index, $gateway := .Values.worker.istio.gateways }}
+{{- with $gateway }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: {{ .name }}
+  labels:
+    {{- include "application.worker.labels" $ | nindent 4 }}
+spec:
+  gatewayClassName: {{ .gatewayClassName }}
+  {{- with .addresses }}
+  addresses:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .infrastructure }}
+  infrastructure:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .listeners }}
+  listeners:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}
+---
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/application-template/values.yaml
+++ b/charts/application-template/values.yaml
@@ -509,6 +509,8 @@ server:
       name: ""
       # -- Waypoint 대상: all | workload | service
       for: all
+    # -- Kubernetes Gateway API Gateway 리소스 배열
+    gateways: []
     # -- Kubernetes Gateway API HTTPRoute 리소스 배열
     httpRoutes: []
     # -- Service에 istio.io/use-waypoint 레이블 추가 (waypoint 이름 지정)
@@ -844,6 +846,8 @@ worker:
       name: ""
       # -- Waypoint 대상: all | workload | service
       for: all
+    # -- Kubernetes Gateway API Gateway 리소스 배열
+    gateways: []
     # -- Kubernetes Gateway API HTTPRoute 리소스 배열
     httpRoutes: []
     # -- Service에 istio.io/use-waypoint 레이블 추가 (waypoint 이름 지정)
@@ -1183,6 +1187,8 @@ scheduler:
       name: ""
       # -- Waypoint 대상: all | workload | service
       for: all
+    # -- Kubernetes Gateway API Gateway 리소스 배열
+    gateways: []
     # -- Kubernetes Gateway API HTTPRoute 리소스 배열
     httpRoutes: []
     # -- Service에 istio.io/use-waypoint 레이블 추가 (waypoint 이름 지정)


### PR DESCRIPTION
## Summary
- `gateway.networking.k8s.io/v1` Gateway 리소스를 Helm chart에서 선언적으로 생성할 수 있도록 지원
- server/worker/scheduler 각 컴포넌트의 `istio` 섹션에 `gateways: []` 배열 추가
- `templates/{server,worker,scheduler}/gateway-api-gateway.yaml` 템플릿 신규 생성 (HTTPRoute와 동일한 pass-through 패턴)
- Chart version `1.10.0` → `1.11.0`

## 사용 예시
```yaml
server:
  istio:
    enabled: true
    gateways:
      - name: auth-sso-gateway
        gatewayClassName: istio
        listeners:
          - name: https
            port: 443
            protocol: HTTPS
            hostname: auth.example.com
```

## Test plan
- [x] `helm template`으로 Gateway 리소스 정상 렌더링 확인
- [x] `gateways: []` (기본값)일 때 출력 없음 확인
- [x] pre-commit hooks (helmlint, helm-docs) 통과 확인