### PR TITLE
feat(application-template): hook에서 ArgoCD hook annotation 지원 추가

### DIFF
--- a/charts/application-template/.helmignore
+++ b/charts/application-template/.helmignore
@@ -20,3 +20,5 @@
 .idea/
 *.tmproj
 .vscode/
+# Test files
+tests/

--- a/charts/application-template/Chart.yaml
+++ b/charts/application-template/Chart.yaml
@@ -9,4 +9,4 @@ maintainers:
   - name: modusign
     url: https://github.com/modusign
 name: application-template
-version: 1.11.0
+version: 1.12.0

--- a/charts/application-template/README.md
+++ b/charts/application-template/README.md
@@ -1,10 +1,40 @@
 # application-template
 
-![Version: 1.11.0](https://img.shields.io/badge/Version-1.11.0-informational?style=flat-square) ![AppVersion: v1.0.0](https://img.shields.io/badge/AppVersion-v1.0.0-informational?style=flat-square)
+![Version: 1.12.0](https://img.shields.io/badge/Version-1.12.0-informational?style=flat-square) ![AppVersion: v1.0.0](https://img.shields.io/badge/AppVersion-v1.0.0-informational?style=flat-square)
 
 A Helm chart for Modusign Applications
 
 **Homepage:** <https://app.modusign.co.kr>
+
+## Testing
+
+차트 템플릿 유닛 테스트는 [helm-unittest](https://github.com/helm-unittest/helm-unittest)를 사용합니다.
+
+### 설치
+
+```bash
+helm plugin install https://github.com/helm-unittest/helm-unittest.git --verify=false
+```
+
+### 테스트 실행
+
+```bash
+# 전체 테스트 실행
+helm unittest charts/application-template
+
+# hooks 테스트만 실행
+helm unittest charts/application-template -f 'tests/hooks/*_test.yaml'
+```
+
+### 테스트 구조
+
+```
+tests/
+└── hooks/
+    ├── job_test.yaml             # hooks/job.yaml 템플릿 테스트
+    ├── secret_test.yaml          # hooks/secret.yaml 템플릿 테스트
+    └── service_account_test.yaml # hooks/service-account.yaml 템플릿 테스트
+```
 
 ## Maintainers
 

--- a/charts/application-template/templates/hooks/job.yaml
+++ b/charts/application-template/templates/hooks/job.yaml
@@ -8,6 +8,15 @@ metadata:
   name: {{ printf "%s-%s" $.Release.Name .name | trunc 63 | trimSuffix "-" }}
   namespace: {{ $.Release.Namespace }}
   annotations:
+    {{- if .argocd }}
+    argocd.argoproj.io/hook: {{ .argocd.hook | default "PreSync" }}
+    {{- if .argocd.syncWave }}
+    argocd.argoproj.io/sync-wave: {{ .argocd.syncWave | quote }}
+    {{- end }}
+    {{- if .argocd.hookDeletePolicy }}
+    argocd.argoproj.io/hook-delete-policy: {{ .argocd.hookDeletePolicy }}
+    {{- end }}
+    {{- else }}
     "helm.sh/hook": {{ .hook | default "pre-install" | quote }}
     {{- if .hookWeight }}
     "helm.sh/hook-weight": {{ .hookWeight | quote }}
@@ -16,6 +25,7 @@ metadata:
     "helm.sh/hook-delete-policy": {{ .hookDeletePolicy | join "," | quote }}
     {{- else }}
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
+    {{- end }}
     {{- end }}
   labels:
     {{- include "application.commonLabels" $ | nindent 4 }}
@@ -85,12 +95,12 @@ spec:
         env:
           {{- toYaml . | nindent 10 }}
         {{- end }}
-        {{- if or .envFrom (.vault.enabled | default false) }}
+        {{- if or .envFrom ((.vault).enabled | default false) }}
         envFrom:
           {{- if .envFrom }}
           {{- toYaml .envFrom | nindent 10 }}
           {{- end }}
-          {{- if .vault.enabled | default false }}
+          {{- if ((.vault).enabled | default false) }}
           - secretRef:
               name: {{ .vault.name | default (printf "%s-%s" $.Release.Name $job.name | trunc 63 | trimSuffix "-") }}
           {{- end }}

--- a/charts/application-template/templates/hooks/secret.yaml
+++ b/charts/application-template/templates/hooks/secret.yaml
@@ -14,6 +14,15 @@ metadata:
     {{- end }}
   annotations:
     avp.kubernetes.io/path: {{ .path }}
+    {{- if .argocd }}
+    argocd.argoproj.io/hook: {{ .argocd.hook | default "PreSync" }}
+    {{- if .argocd.syncWave }}
+    argocd.argoproj.io/sync-wave: {{ .argocd.syncWave | quote }}
+    {{- end }}
+    {{- if .argocd.hookDeletePolicy }}
+    argocd.argoproj.io/hook-delete-policy: {{ .argocd.hookDeletePolicy }}
+    {{- end }}
+    {{- else }}
     "helm.sh/hook": {{ $job.hook | default "pre-install" | quote }}
     {{- if $job.hookWeight }}
     "helm.sh/hook-weight": {{ $job.hookWeight | quote }}
@@ -22,6 +31,7 @@ metadata:
     "helm.sh/hook-delete-policy": {{ $job.hookDeletePolicy | join "," | quote }}
     {{- else }}
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
+    {{- end }}
     {{- end }}
 type: Opaque
 stringData:

--- a/charts/application-template/templates/hooks/service-account.yaml
+++ b/charts/application-template/templates/hooks/service-account.yaml
@@ -19,15 +19,25 @@ metadata:
     {{ $key }}: {{ $value | quote }}
     {{- end }}
   {{- end }}
+    {{- if $job.argocd }}
+    argocd.argoproj.io/hook: {{ $job.argocd.hook | default "PreSync" }}
+    {{- if $job.argocd.syncWave }}
+    argocd.argoproj.io/sync-wave: {{ $job.argocd.syncWave | quote }}
+    {{- end }}
+    {{- if $job.argocd.hookDeletePolicy }}
+    argocd.argoproj.io/hook-delete-policy: {{ $job.argocd.hookDeletePolicy }}
+    {{- end }}
+    {{- else }}
     "helm.sh/hook": {{ $job.hook | default "pre-install" | quote }}
     {{- if $job.hookWeight }}
     "helm.sh/hook-weight": {{ $job.hookWeight | quote }}
     {{- end }}
-  {{- if $job.hookDeletePolicy }}
+    {{- if $job.hookDeletePolicy }}
     "helm.sh/hook-delete-policy": {{ $job.hookDeletePolicy | join "," | quote }}
-  {{- else }}
+    {{- else }}
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
-  {{- end }}
+    {{- end }}
+    {{- end }}
 {{- with $.Values.global.imagePullSecrets }}
 imagePullSecrets:
   {{- toYaml . | nindent 4 }}

--- a/charts/application-template/tests/hooks/job_test.yaml
+++ b/charts/application-template/tests/hooks/job_test.yaml
@@ -1,0 +1,172 @@
+suite: hooks - job
+templates:
+  - templates/hooks/job.yaml
+
+tests:
+  - it: hook.enabled=false이면 Job이 렌더링되지 않아야 한다
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: ArgoCD hook 설정 시 argocd.argoproj.io/hook annotation이 적용되어야 한다
+    set:
+      hook:
+        enabled: true
+        jobs:
+          - name: db-migration
+            argocd:
+              hook: PreSync
+              syncWave: "-1"
+              hookDeletePolicy: BeforeHookCreation
+            image:
+              hub: 387526857220.dkr.ecr.ap-northeast-2.amazonaws.com/modusign
+              repository: myapp
+              tag: abc123
+    asserts:
+      - isKind:
+          of: Job
+      - equal:
+          path: metadata.annotations["argocd.argoproj.io/hook"]
+          value: PreSync
+
+  - it: ArgoCD hook 설정 시 sync-wave annotation이 적용되어야 한다
+    set:
+      hook:
+        enabled: true
+        jobs:
+          - name: db-migration
+            argocd:
+              hook: PreSync
+              syncWave: "-1"
+              hookDeletePolicy: BeforeHookCreation
+            image:
+              hub: 387526857220.dkr.ecr.ap-northeast-2.amazonaws.com/modusign
+              repository: myapp
+              tag: abc123
+    asserts:
+      - equal:
+          path: metadata.annotations["argocd.argoproj.io/sync-wave"]
+          value: "-1"
+
+  - it: ArgoCD hook 설정 시 hook-delete-policy annotation이 적용되어야 한다
+    set:
+      hook:
+        enabled: true
+        jobs:
+          - name: db-migration
+            argocd:
+              hook: PreSync
+              syncWave: "-1"
+              hookDeletePolicy: BeforeHookCreation
+            image:
+              hub: 387526857220.dkr.ecr.ap-northeast-2.amazonaws.com/modusign
+              repository: myapp
+              tag: abc123
+    asserts:
+      - equal:
+          path: metadata.annotations["argocd.argoproj.io/hook-delete-policy"]
+          value: BeforeHookCreation
+
+  - it: ArgoCD hook 설정 시 helm.sh/hook annotation이 없어야 한다
+    set:
+      hook:
+        enabled: true
+        jobs:
+          - name: db-migration
+            argocd:
+              hook: PreSync
+            image:
+              hub: 387526857220.dkr.ecr.ap-northeast-2.amazonaws.com/modusign
+              repository: myapp
+              tag: abc123
+    asserts:
+      - isNull:
+          path: metadata.annotations["helm.sh/hook"]
+
+  - it: argocd 블록이 없으면 helm.sh/hook annotation이 적용되어야 한다
+    set:
+      hook:
+        enabled: true
+        jobs:
+          - name: pre-upgrade-job
+            hook: pre-upgrade
+            image:
+              hub: 387526857220.dkr.ecr.ap-northeast-2.amazonaws.com/modusign
+              repository: myapp
+              tag: abc123
+    asserts:
+      - isKind:
+          of: Job
+      - equal:
+          path: metadata.annotations["helm.sh/hook"]
+          value: pre-upgrade
+      - isNull:
+          path: metadata.annotations["argocd.argoproj.io/hook"]
+
+  - it: Helm hook에 hookWeight annotation이 설정되어야 한다
+    set:
+      hook:
+        enabled: true
+        jobs:
+          - name: pre-upgrade-job
+            hook: pre-upgrade
+            hookWeight: "5"
+            image:
+              hub: 387526857220.dkr.ecr.ap-northeast-2.amazonaws.com/modusign
+              repository: myapp
+              tag: abc123
+    asserts:
+      - equal:
+          path: metadata.annotations["helm.sh/hook-weight"]
+          value: "5"
+
+  - it: Helm hook에 hookDeletePolicy annotation이 설정되어야 한다
+    set:
+      hook:
+        enabled: true
+        jobs:
+          - name: pre-upgrade-job
+            hook: pre-upgrade
+            hookDeletePolicy:
+              - before-hook-creation
+              - hook-succeeded
+            image:
+              hub: 387526857220.dkr.ecr.ap-northeast-2.amazonaws.com/modusign
+              repository: myapp
+              tag: abc123
+    asserts:
+      - equal:
+          path: metadata.annotations["helm.sh/hook-delete-policy"]
+          value: before-hook-creation,hook-succeeded
+
+  - it: vault 미설정 시 패닉 없이 렌더링되어야 한다
+    set:
+      hook:
+        enabled: true
+        jobs:
+          - name: pre-upgrade-job
+            hook: pre-upgrade
+            image:
+              hub: 387526857220.dkr.ecr.ap-northeast-2.amazonaws.com/modusign
+              repository: myapp
+              tag: abc123
+    asserts:
+      - isKind:
+          of: Job
+
+  - it: Job 이름이 release name과 job name 조합이어야 한다
+    set:
+      hook:
+        enabled: true
+        jobs:
+          - name: db-migration
+            argocd:
+              hook: PreSync
+            image:
+              hub: 387526857220.dkr.ecr.ap-northeast-2.amazonaws.com/modusign
+              repository: myapp
+              tag: abc123
+    asserts:
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-db-migration

--- a/charts/application-template/tests/hooks/secret_test.yaml
+++ b/charts/application-template/tests/hooks/secret_test.yaml
@@ -1,0 +1,160 @@
+suite: hooks - secret
+templates:
+  - templates/hooks/secret.yaml
+
+tests:
+  - it: vault.enabled=false이면 Secret이 렌더링되지 않아야 한다
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: Helm hook + vault 설정 시 helm.sh/hook annotation이 적용되어야 한다
+    set:
+      hook:
+        enabled: true
+        jobs:
+          - name: pre-upgrade-job
+            hook: pre-upgrade
+            vault:
+              enabled: true
+              path: argo-system:myapp-stage
+              secrets:
+                MY_SECRET: <MY_SECRET>
+    asserts:
+      - isKind:
+          of: Secret
+      - equal:
+          path: metadata.annotations["helm.sh/hook"]
+          value: pre-upgrade
+      - isNull:
+          path: metadata.annotations["argocd.argoproj.io/hook"]
+
+  - it: Helm hook의 기본 hookDeletePolicy가 Secret에도 적용되어야 한다
+    set:
+      hook:
+        enabled: true
+        jobs:
+          - name: pre-upgrade-job
+            hook: pre-upgrade
+            hookDeletePolicy:
+              - before-hook-creation
+              - hook-succeeded
+            vault:
+              enabled: true
+              path: argo-system:myapp-stage
+              secrets:
+                MY_SECRET: <MY_SECRET>
+    asserts:
+      - equal:
+          path: metadata.annotations["helm.sh/hook-delete-policy"]
+          value: before-hook-creation,hook-succeeded
+
+  - it: ArgoCD hook + vault 설정 시 argocd.argoproj.io/hook annotation이 적용되어야 한다
+    set:
+      hook:
+        enabled: true
+        jobs:
+          - name: db-migration
+            argocd:
+              hook: PreSync
+            vault:
+              enabled: true
+              path: argo-system:myapp-stage
+              argocd:
+                hook: PreSync
+                syncWave: "-2"
+                hookDeletePolicy: HookSucceeded
+              secrets:
+                MY_SECRET: <MY_SECRET>
+    asserts:
+      - isKind:
+          of: Secret
+      - equal:
+          path: metadata.annotations["argocd.argoproj.io/hook"]
+          value: PreSync
+      - isNull:
+          path: metadata.annotations["helm.sh/hook"]
+
+  - it: ArgoCD hook + vault 설정 시 sync-wave annotation이 적용되어야 한다
+    set:
+      hook:
+        enabled: true
+        jobs:
+          - name: db-migration
+            argocd:
+              hook: PreSync
+            vault:
+              enabled: true
+              path: argo-system:myapp-stage
+              argocd:
+                hook: PreSync
+                syncWave: "-2"
+                hookDeletePolicy: HookSucceeded
+              secrets:
+                MY_SECRET: <MY_SECRET>
+    asserts:
+      - equal:
+          path: metadata.annotations["argocd.argoproj.io/sync-wave"]
+          value: "-2"
+
+  - it: ArgoCD hook + vault 설정 시 hook-delete-policy annotation이 적용되어야 한다
+    set:
+      hook:
+        enabled: true
+        jobs:
+          - name: db-migration
+            argocd:
+              hook: PreSync
+            vault:
+              enabled: true
+              path: argo-system:myapp-stage
+              argocd:
+                hook: PreSync
+                syncWave: "-2"
+                hookDeletePolicy: HookSucceeded
+              secrets:
+                MY_SECRET: <MY_SECRET>
+    asserts:
+      - equal:
+          path: metadata.annotations["argocd.argoproj.io/hook-delete-policy"]
+          value: HookSucceeded
+
+  - it: vault Secret에 avp.kubernetes.io/path annotation이 설정되어야 한다
+    set:
+      hook:
+        enabled: true
+        jobs:
+          - name: db-migration
+            argocd:
+              hook: PreSync
+            vault:
+              enabled: true
+              path: argo-system:myapp-stage
+              argocd:
+                hook: PreSync
+              secrets:
+                MY_SECRET: <MY_SECRET>
+    asserts:
+      - equal:
+          path: metadata.annotations["avp.kubernetes.io/path"]
+          value: argo-system:myapp-stage
+
+  - it: Secret 이름이 release name과 job name 조합이어야 한다
+    set:
+      hook:
+        enabled: true
+        jobs:
+          - name: db-migration
+            argocd:
+              hook: PreSync
+            vault:
+              enabled: true
+              path: argo-system:myapp-stage
+              argocd:
+                hook: PreSync
+              secrets:
+                MY_SECRET: <MY_SECRET>
+    asserts:
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-db-migration

--- a/charts/application-template/tests/hooks/service_account_test.yaml
+++ b/charts/application-template/tests/hooks/service_account_test.yaml
@@ -1,0 +1,130 @@
+suite: hooks - service account
+templates:
+  - templates/hooks/service-account.yaml
+
+tests:
+  - it: serviceAccount.create가 없으면 ServiceAccount가 렌더링되지 않아야 한다
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: Helm hook + serviceAccount.create=true 시 helm.sh/hook annotation이 적용되어야 한다
+    set:
+      hook:
+        enabled: true
+        jobs:
+          - name: pre-upgrade-job
+            hook: pre-upgrade
+            serviceAccount:
+              create: true
+    asserts:
+      - isKind:
+          of: ServiceAccount
+      - equal:
+          path: metadata.annotations["helm.sh/hook"]
+          value: pre-upgrade
+      - isNull:
+          path: metadata.annotations["argocd.argoproj.io/hook"]
+
+  - it: Helm hook의 기본 hookDeletePolicy가 ServiceAccount에도 적용되어야 한다
+    set:
+      hook:
+        enabled: true
+        jobs:
+          - name: pre-upgrade-job
+            hook: pre-upgrade
+            hookDeletePolicy:
+              - before-hook-creation
+              - hook-succeeded
+            serviceAccount:
+              create: true
+    asserts:
+      - equal:
+          path: metadata.annotations["helm.sh/hook-delete-policy"]
+          value: before-hook-creation,hook-succeeded
+
+  - it: ArgoCD hook + serviceAccount.create=true 시 argocd.argoproj.io/hook annotation이 적용되어야 한다
+    set:
+      hook:
+        enabled: true
+        jobs:
+          - name: db-migration
+            argocd:
+              hook: PreSync
+              syncWave: "-1"
+              hookDeletePolicy: BeforeHookCreation
+            serviceAccount:
+              create: true
+    asserts:
+      - isKind:
+          of: ServiceAccount
+      - equal:
+          path: metadata.annotations["argocd.argoproj.io/hook"]
+          value: PreSync
+      - isNull:
+          path: metadata.annotations["helm.sh/hook"]
+
+  - it: ArgoCD hook + serviceAccount.create=true 시 sync-wave annotation이 적용되어야 한다
+    set:
+      hook:
+        enabled: true
+        jobs:
+          - name: db-migration
+            argocd:
+              hook: PreSync
+              syncWave: "-1"
+              hookDeletePolicy: BeforeHookCreation
+            serviceAccount:
+              create: true
+    asserts:
+      - equal:
+          path: metadata.annotations["argocd.argoproj.io/sync-wave"]
+          value: "-1"
+
+  - it: ArgoCD hook + serviceAccount.create=true 시 hook-delete-policy annotation이 적용되어야 한다
+    set:
+      hook:
+        enabled: true
+        jobs:
+          - name: db-migration
+            argocd:
+              hook: PreSync
+              syncWave: "-1"
+              hookDeletePolicy: BeforeHookCreation
+            serviceAccount:
+              create: true
+    asserts:
+      - equal:
+          path: metadata.annotations["argocd.argoproj.io/hook-delete-policy"]
+          value: BeforeHookCreation
+
+  - it: ServiceAccount 이름이 release name과 job name 조합이어야 한다
+    set:
+      hook:
+        enabled: true
+        jobs:
+          - name: db-migration
+            argocd:
+              hook: PreSync
+            serviceAccount:
+              create: true
+    asserts:
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-db-migration
+
+  - it: serviceAccount.name이 지정되면 해당 이름으로 ServiceAccount가 생성되어야 한다
+    set:
+      hook:
+        enabled: true
+        jobs:
+          - name: db-migration
+            argocd:
+              hook: PreSync
+            serviceAccount:
+              create: true
+              name: custom-sa
+    asserts:
+      - equal:
+          path: metadata.name
+          value: custom-sa

--- a/charts/application-template/values.yaml
+++ b/charts/application-template/values.yaml
@@ -162,11 +162,14 @@ hook:
     #   command: ["sh", "-c"]
     #   args: ["echo 'Running pre-install job'"]
     #   # -- serviceAccount(Optional)
-    #   # When enabled, a service account will be created with the name of the job
-    #   # If the name is not specified or create is false, it will be set to the name of the job
-    #   serviceAccount:
-    #     create: true
-    #     name: application-template-pre-install-job
+    #   # To use an existing ServiceAccount (e.g. IRSA), set create: false and specify name.
+    #   # To create a new ServiceAccount, set create: true.
+    #   # serviceAccount:
+    #   #   create: false
+    #   #   name: my-existing-irsa           # use existing SA (no SA resource created)
+    #   # serviceAccount:
+    #   #   create: true
+    #   #   name: application-template-pre-install-job  # create new SA with this name
     #   envFrom: []
     #   # -- envs(Optional)
     #   env: []

--- a/charts/application-template/values.yaml
+++ b/charts/application-template/values.yaml
@@ -139,15 +139,23 @@ hook:
   jobs:
     []
     # - name: pre-install-job
-    #   # -- hook type(Required)
+    #   # -- hook type(Required) - Helm hook type (ignored when argocd is set)
     #   # pre-install, post-install, pre-upgrade, post-upgrade, pre-delete, post-delete
     #   hook: pre-install
-    #   # -- hookWeight(Optional) - Weight of the hook
+    #   # -- hookWeight(Optional) - Weight of the hook (Helm only)
     #   hookWeight: "5"
-    #   # -- hookDeletePolicy(Optional) - List of hook delete policies
+    #   # -- hookDeletePolicy(Optional) - List of hook delete policies (Helm only)
     #   hookDeletePolicy:
     #     - before-hook-creation
     #     - hook-succeeded
+    #   # -- argocd(Optional) - ArgoCD hook configuration
+    #   # When set, ArgoCD annotations are used instead of Helm hook annotations.
+    #   # ArgoCD hook types: PreSync, Sync, PostSync, SyncFail, Skip
+    #   # argocd:
+    #   #   hook: PreSync
+    #   #   syncWave: "-1"
+    #   #   # ArgoCD hookDeletePolicy: HookSucceeded, HookFailed, BeforeHookCreation
+    #   #   hookDeletePolicy: BeforeHookCreation
     #   image:
     #     repository: busybox
     #     tag: latest
@@ -170,6 +178,12 @@ hook:
     #     path: stage-default/application/job/${service}
     #     secrets:
     #       test: test
+    #     # -- argocd(Optional) - ArgoCD hook annotations for the vault Secret
+    #     # When set, ArgoCD annotations are used instead of Helm hook annotations.
+    #     # argocd:
+    #     #   hook: PreSync
+    #     #   syncWave: "-2"
+    #     #   hookDeletePolicy: HookSucceeded
     # - name: post-install-job
     #   hook: post-install
     #   command: ["sh", "-c"]


### PR DESCRIPTION
## Summary

- `hook.jobs[].argocd` 블록 설정 시 ArgoCD annotation 사용, 미설정 시 기존 Helm hook 동작 유지 (하위 호환)
- `hook.jobs[].vault.argocd` 블록으로 vault Secret에도 동일하게 적용
- `vault` 미설정 시 nil pointer 버그 수정: `.vault` 대신 `(.vault)` 사용하면 js의 ?? 처럼 nil일때도 오류 안난다고 합니다.
- helm-unittest 유닛 테스트 26개 추가
    - helm-unittest 이 제일 많이 쓰는 것 같아서 추가했습니다.

## Usage

```yaml
hook:
  enabled: true
  jobs:
    - name: db-migration
      argocd:
        hook: PreSync
        syncWave: "-1"
        hookDeletePolicy: BeforeHookCreation
      vault:
        enabled: true
        path: argo-system:myapp-stage
        argocd:
          hook: PreSync
          syncWave: "-2"
          hookDeletePolicy: HookSucceeded
        secrets:
          MY_SECRET: <MY_SECRET>
```

---

**Jira:** [MD-23431](https://modusign.atlassian.net/browse/MD-23431) [MD-23568](https://modusign.atlassian.net/browse/MD-23568)

[MD-23431]: https://modusign.atlassian.net/browse/MD-23431?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MD-23568]: https://modusign.atlassian.net/browse/MD-23568?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ