### PR TITLE
feat(application-template): extraObjects 기능 추가

### DIFF
--- a/charts/application-template/Chart.yaml
+++ b/charts/application-template/Chart.yaml
@@ -9,4 +9,4 @@ maintainers:
   - name: modusign
     url: https://github.com/modusign
 name: application-template
-version: 1.12.0
+version: 1.12.1

--- a/charts/application-template/templates/extra-objects.yaml
+++ b/charts/application-template/templates/extra-objects.yaml
@@ -1,0 +1,8 @@
+{{- range $manifest := .Values.extraObjects }}
+---
+{{- if typeIs "string" $manifest }}
+{{ tpl $manifest $ }}
+{{- else }}
+{{ tpl (toYaml $manifest) $ }}
+{{- end }}
+{{- end }}

--- a/charts/application-template/values.yaml
+++ b/charts/application-template/values.yaml
@@ -1223,3 +1223,30 @@ scheduler:
         enabled: false
         highCpuUsageThreshold: 70
         highMemoryUsageThreshold: 70
+
+# -- Extra Kubernetes manifests to deploy alongside the chart.
+# Each entry can be a structured object or a string with Go template syntax.
+# The chart root context is available for template interpolation.
+extraObjects: []
+  # Structured object format:
+  # - apiVersion: v1
+  #   kind: ConfigMap
+  #   metadata:
+  #     name: my-extra-config
+  #   data:
+  #     key: value
+  #
+  # - apiVersion: external-secrets.io/v1beta1
+  #   kind: ExternalSecret
+  #   metadata:
+  #     name: my-secret
+  #   spec: {}
+  #
+  # String format with Helm template interpolation:
+  # - |
+  #   apiVersion: v1
+  #   kind: ConfigMap
+  #   metadata:
+  #     name: {{ include "application.server.name" . }}-extra
+  #   data:
+  #     env: {{ .Values.global.runtimeEnv }}


### PR DESCRIPTION
## 요약

application-template Helm 차트에 `extraObjects` 필드를 추가하여, 차트가 관리하는 리소스 외에 임의의 Kubernetes 매니페스트를 함께 배포할 수 있도록 지원합니다.

Istio AuthorizationPolicy처럼 서비스별로 내용이 달라 추상화하기 어려운 리소스를 values에서 직접 정의할 수 있습니다.

## 변경 사항

- `values.yaml`에 `extraObjects: []` 추가 (구조체 형식 및 문자열 형식 예시 포함)
- `templates/extra-objects.yaml` 신규 생성 — 타입 인식 렌더링 지원 (YAML 객체 및 Go 템플릿 문자열 모두 지원)
- 차트 버전 `1.12.0` → `1.12.1` 범프

## 테스트

`helm lint` 및 `helm template`으로 검증 완료.

## 참고

- 키 이름 `extraObjects`는 ArgoCD, Grafana/Loki, cert-manager, Traefik 등 최신 Helm 차트의 표준 컨벤션을 따름
- 구조체 객체와 Helm 템플릿 인터폴레이션이 포함된 멀티라인 문자열 항목 모두 지원