### PR TITLE
chore: deprecated github actions 버전 업데이트

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
## 요약
- Node.js 20 deprecation 대응으로 GitHub Actions 버전 업데이트
- `actions/checkout@v[1-4]` → `@v6`
- `actions/setup-node@v[1-4]` → `@v6`

## 원인
GitHub의 [Node.js 20 deprecation 공지](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)에 따라 2026-06-02부터 Node.js 24로 강제 전환되며, 2026-09-16에 Node.js 20이 runner에서 제거됩니다.

## 검증
- GitHub Actions CI 통과 확인

## 관련 티켓
- [MD-25032](https://modusign.atlassian.net/browse/MD-25032) (상위 [MD-25013](https://modusign.atlassian.net/browse/MD-25013))

[MD-25032]: https://modusign.atlassian.net/browse/MD-25032?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MD-25013]: https://modusign.atlassian.net/browse/MD-25013?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ